### PR TITLE
Supports apt preferences to downgrade priority

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ services:
 install:
   - pip install -r molecule/requirements.txt
 script:
-  - make test-repo
+  - make ci

--- a/Makefile
+++ b/Makefile
@@ -3,18 +3,24 @@ SHELL := /bin/bash
 PWD := $(shell pwd)
 
 .PHONY: test-packages
-test-repo: ## Configures container with SGOS packages.
+test-packages: ## Configures container with SGOS packages.
 	molecule test -s default
+
+.PHONY: test-upgrade
+test-upgrade: ## Configures container with full upgrade to SGOS repos.
+	molecule test -s all-packages
 
 .PHONY: test-kernel
 test-kernel: ## Configures libvirt VM with SGOS hardened kernel.
 	molecule test -s grsec-kernel
 
 .PHONY: test
-test: test-repo test-kernel ## Runs all tests from a clean slate.
-	molecule test -s grsec-kernel
+test: test-packages test-upgrade test-kernel ## Runs all tests from a clean slate.
 
-# Explaination of the below shell command should it ever break.
+.PHONY: ci
+ci: test-packages test-upgrade # Runs all container tests (no VMs).
+
+# Explanation of the below shell command should it ever break.
 # 1. Set the field separator to ": ##" and any make targets that might appear between : and ##
 # 2. Use sed-like syntax to remove the make targets
 # 3. Format the split fields into $$1) the target name (in blue) and $$2) the target descrption
@@ -23,7 +29,6 @@ test: test-repo test-kernel ## Runs all tests from a clean slate.
 # 6. Format columns with colon as delimiter.
 .PHONY: help
 help: ## Print this message and exit.
-	@printf "Makefile for developing and testing SecureDrop.\n"
 	@printf "Subcommands:\n\n"
 	@awk 'BEGIN {FS = ":.*?## "} /^[0-9a-zA-Z_-]+:.*?## / {printf "\033[36m%s\033[0m : %s\n", $$1, $$2}' $(MAKEFILE_LIST) \
 		| sort \

--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ subgraph_apt_repos:
 # Packages to install after Subgraph OS repos are configured, e.g.
 # macouflage, paxrat.
 subgraph_packages: []
+
+# Downgrade priority so that only explicitly requested packages will
+# be installed, never upgrades of other packages standard in Debian.
+# Override by creating a new flat file and setting the filepath here.
+subgraph_apt_preferences_src_file: "{{ role_path+'/files/subgraph_apt_preferences' }}"
 ```
 
 Example Playbook

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,3 +23,8 @@ subgraph_apt_repos:
 # Packages to install after Subgraph OS repos are configured, e.g.
 # macouflage, paxrat.
 subgraph_packages: []
+
+# Downgrade priority so that only explicitly requested packages will
+# be installed, never upgrades of other packages standard in Debian.
+# Override by creating a new flat file and setting the filepath here.
+subgraph_apt_preferences_src_file: "{{ role_path+'/files/subgraph_apt_preferences' }}"

--- a/files/subgraph_apt_preferences
+++ b/files/subgraph_apt_preferences
@@ -1,0 +1,3 @@
+Package: *
+Pin: origin devrepo.subgraph.com
+Pin-Priority: 1

--- a/molecule/all-packages/Dockerfile.j2
+++ b/molecule/all-packages/Dockerfile.j2
@@ -1,0 +1,7 @@
+FROM {{ item.image }}
+
+RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get upgrade -y && apt-get install -y python sudo bash ca-certificates && apt-get clean; \
+    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python python-devel python2-dnf bash && dnf clean all; \
+    elif [ $(command -v yum) ]; then yum makecache fast && yum update -y && yum install -y python sudo yum-plugin-ovl bash && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
+    elif [ $(command -v zypper) ]; then zypper refresh && zypper update -y && zypper install -y python sudo bash python-xml && zypper clean -a; \
+    elif [ $(command -v apk) ]; then apk update && apk add --no-cache python sudo bash ca-certificates; fi

--- a/molecule/all-packages/INSTALL.rst
+++ b/molecule/all-packages/INSTALL.rst
@@ -1,0 +1,16 @@
+*******
+Install
+*******
+
+Requirements
+============
+
+* Docker Engine
+* docker-py
+
+Install
+=======
+
+.. code-block:: bash
+
+  $ sudo pip install docker-py

--- a/molecule/all-packages/create.yml
+++ b/molecule/all-packages/create.yml
@@ -1,0 +1,47 @@
+---
+- name: Create
+  hosts: localhost
+  connection: local
+  gather_facts: False
+  no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
+  vars:
+    molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
+    molecule_ephemeral_directory: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}"
+    molecule_scenario_directory: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}"
+    molecule_yml: "{{ lookup('file', molecule_file) | from_yaml }}"
+  tasks:
+    - name: Create Dockerfiles from image names
+      template:
+        src: "{{ molecule_scenario_directory }}/Dockerfile.j2"
+        dest: "{{ molecule_ephemeral_directory }}/Dockerfile_{{ item.image | regex_replace('[^a-zA-Z0-9_]', '_') }}"
+      with_items: "{{ molecule_yml.platforms }}"
+      register: platforms
+
+    - name: Discover local Docker images
+      docker_image_facts:
+        name: "molecule_local/{{ item.item.name }}"
+      with_items: "{{ platforms.results }}"
+      register: docker_images
+
+    - name: Build an Ansible compatible image
+      docker_image:
+        path: "{{ molecule_ephemeral_directory }}"
+        name: "molecule_local/{{ item.item.image }}"
+        dockerfile: "{{ item.item.dockerfile | default(item.invocation.module_args.dest) }}"
+        force: "{{ item.item.force | default(True) }}"
+      with_items: "{{ platforms.results }}"
+      when: platforms.changed or docker_images.results | map(attribute='images') | select('equalto', []) | list | count >= 0
+
+    - name: Create molecule instance(s)
+      docker_container:
+        name: "{{ item.name }}"
+        hostname: "{{ item.name }}"
+        image: "molecule_local/{{ item.image }}"
+        state: started
+        recreate: False
+        log_driver: syslog
+        command: "{{ item.command | default('sleep infinity') }}"
+        privileged: "{{ item.privileged | default(omit) }}"
+        volumes: "{{ item.volumes | default(omit) }}"
+        capabilities: "{{ item.capabilities | default(omit) }}"
+      with_items: "{{ molecule_yml.platforms }}"

--- a/molecule/all-packages/destroy.yml
+++ b/molecule/all-packages/destroy.yml
@@ -1,0 +1,16 @@
+---
+- name: Destroy
+  hosts: localhost
+  connection: local
+  gather_facts: False
+  no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
+  vars:
+    molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
+    molecule_yml: "{{ lookup('file', molecule_file) | from_yaml }}"
+  tasks:
+    - name: Destroy molecule instance(s)
+      docker_container:
+        name: "{{ item.name }}"
+        state: absent
+        force_kill: "{{ item.force_kill | default(True) }}"
+      with_items: "{{ molecule_yml.platforms }}"

--- a/molecule/all-packages/molecule.yml
+++ b/molecule/all-packages/molecule.yml
@@ -1,0 +1,21 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+lint:
+  name: yamllint
+platforms:
+  - name: subgraph_container
+    # Subgraph OS is based on Debian Stretch
+    image: debian:stretch
+provisioner:
+  name: ansible
+  lint:
+    name: ansible-lint
+scenario:
+  name: all-packages
+verifier:
+  name: testinfra
+  lint:
+    name: flake8

--- a/molecule/all-packages/playbook.yml
+++ b/molecule/all-packages/playbook.yml
@@ -1,0 +1,17 @@
+---
+- name: Converge
+  hosts: all
+  vars:
+    subgraph_packages:
+      - macouflage
+      - paxrat
+    # Disable pinning, allowing all packages to be upgraded.
+    subgraph_apt_preferences_src_file: /dev/null
+  roles:
+    - role: ansible-role-subgraph-packages
+  tasks:
+    - name: Upgrade all apt packages.
+      apt:
+        update_cache: yes
+        cache_valid_time: 3600
+        upgrade: dist

--- a/molecule/all-packages/tests/test_packages.py
+++ b/molecule/all-packages/tests/test_packages.py
@@ -1,0 +1,17 @@
+import os
+
+import pytest
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
+
+
+@pytest.mark.parametrize('pkg', [
+    'paxrat',
+    'macouflage'
+])
+def test_subgraph_packages(host, pkg):
+
+    p = host.package(pkg)
+    assert p.is_installed

--- a/molecule/all-packages/tests/test_platform.py
+++ b/molecule/all-packages/tests/test_platform.py
@@ -1,0 +1,11 @@
+def test_subgraph_distribution(host):
+    """
+    The base-files version overwrites the standard Debian Stretch
+    distribution information in favor of Subgraph-specific options.
+    """
+
+    return True
+    assert host.system_info.type == 'linux'
+    assert host.system_info.distribution == 'subgraph'
+    assert host.system_info.codename == 'n/a'
+    assert host.system_info.release == '1.0'

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -7,3 +7,9 @@
       - paxrat
   roles:
     - role: ansible-role-subgraph-packages
+  tasks:
+    - name: Upgrade all apt packages.
+      apt:
+        update_cache: yes
+        cache_valid_time: 3600
+        upgrade: dist

--- a/molecule/default/tests/test_platform.py
+++ b/molecule/default/tests/test_platform.py
@@ -1,0 +1,9 @@
+def test_debian_distribution(host):
+    """
+    Apt pinning should prevent upgrade of base-files to Subgraph's
+    version, and stick with the default Debian info.
+    """
+
+    assert host.system_info.type == 'linux'
+    assert host.system_info.distribution == 'debian'
+    assert host.system_info.codename == 'stretch'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,6 +8,11 @@
     cache_valid_time: 3600
   with_items: "{{ subgraph_pre_packages }}"
 
+- name: Copy apt preferences to decrease Subgraph repo priority.
+  copy:
+    src: "{{ subgraph_apt_preferences_src_file }}"
+    dest: /etc/apt/preferences.d/subgraph_repo
+
 - name: Add Subgraph repo GPG key.
   apt_key:
     data: "{{ lookup('file', 'subgraph_os_apt_key.asc') }}"


### PR DESCRIPTION
By default, the role will now configure apt to *permit* installation of
packages from the Subgraph repositories, but won't automatically upgrade
packages already installed from a separate repo to newer versions
maintained by Subgraph.

This change prevents automatic upgrades of `base-files`, which convert
`lsb_release -a` output to Subgraph distribution information, rather
than the default Debian Stretch.

The apt preferences settings can be overridden by passing in a path to a
custom flat file.  Not using a string var because the special characters
in the file content were causing templating errors when used with copy's
content= parameter.